### PR TITLE
Fix Supabase URL used in schema scripts

### DIFF
--- a/apply-schema-direct.js
+++ b/apply-schema-direct.js
@@ -1,6 +1,6 @@
 const https = require('https');
 
-const supabaseUrl = 'https://hycudcwtuocmufahpsnmr.supabase.co';
+const supabaseUrl = 'https://hycudcwtuocmufhpsnmr.supabase.co';
 const serviceRoleKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh5Y3VkY3d0dW9jbXVmYWhwc25tciIsInJvbGUiOiJzZXJ2aWNlX3JvbGUiLCJpYXQiOjE3MzcwNDEwODQsImV4cCI6MjA1MjYxNzA4NH0.WN6r0TejH0LKqTPmQYyQfF8Q7SMLM-yfF1x8a_BPVYs';
 
 async function executeSql(sql) {
@@ -8,7 +8,7 @@ async function executeSql(sql) {
     const data = JSON.stringify({ query: sql });
     
     const options = {
-      hostname: 'hycudcwtuocmufahpsnmr.supabase.co',
+      hostname: 'hycudcwtuocmufhpsnmr.supabase.co',
       port: 443,
       path: '/rest/v1/rpc/exec_sql',
       method: 'POST',

--- a/scripts/apply-schema.js
+++ b/scripts/apply-schema.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Configuração do Supabase
-const supabaseUrl = 'https://hycudcwtuocmufahpsnmr.supabase.co';
+const supabaseUrl = 'https://hycudcwtuocmufhpsnmr.supabase.co';
 const supabaseServiceKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh5Y3VkY3d0dW9jbXVmYWhwc25tciIsInJvbGUiOiJzZXJ2aWNlX3JvbGUiLCJpYXQiOjE3MzcwNDEwODQsImV4cCI6MjA1MjYxNzA4NH0.WN6r0TejH0LKqTPmQYyQfF8Q7SMLM-yfF1x8a_BPVYs';
 
 const supabase = createClient(supabaseUrl, supabaseServiceKey);

--- a/scripts/apply-urgent-migrations.js
+++ b/scripts/apply-urgent-migrations.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Configuração do Supabase
-const supabaseUrl = 'https://hycudcwtuocmufahpsnmr.supabase.co';
+const supabaseUrl = 'https://hycudcwtuocmufhpsnmr.supabase.co';
 const supabaseServiceKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imh5Y3VkY3d0dW9jbXVmYWhwc25tciIsInJvbGUiOiJzZXJ2aWNlX3JvbGUiLCJpYXQiOjE3MzcwNDEwODQsImV4cCI6MjA1MjYxNzA4NH0.WN6r0TejH0LKqTPmQYyQfF8Q7SMLM-yfF1x8a_BPVYs';
 
 const supabase = createClient(supabaseUrl, supabaseServiceKey);


### PR DESCRIPTION
## Summary
- correct Supabase project URL in apply-schema.js
- correct Supabase project URL in apply-urgent-migrations.js
- correct Supabase project URL in apply-schema-direct.js

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861f3652dcc832fbdcbef784e21bb87